### PR TITLE
Implemented 8x8 matrix transpose using intrinsic and scalar methods with gtest

### DIFF
--- a/Assembly_code-transpose/O1-assembly
+++ b/Assembly_code-transpose/O1-assembly
@@ -1,0 +1,80 @@
+	.file	"transpose.cpp"
+	.text
+	.globl	_Z16transpose_scalarPA8_KfPA8_f
+	.type	_Z16transpose_scalarPA8_KfPA8_f, @function
+_Z16transpose_scalarPA8_KfPA8_f:
+.LFB7578:
+	.cfi_startproc
+	endbr64
+	leaq	32(%rdi), %rcx
+	leaq	32(%rsi), %rdi
+.L2:
+	leaq	-32(%rcx), %rax
+	movq	%rsi, %rdx
+.L3:
+	vmovss	(%rax), %xmm0
+	vmovss	%xmm0, (%rdx)
+	addq	$4, %rax
+	addq	$32, %rdx
+	cmpq	%rcx, %rax
+	jne	.L3
+	addq	$4, %rsi
+	addq	$32, %rcx
+	cmpq	%rdi, %rsi
+	jne	.L2
+	ret
+	.cfi_endproc
+.LFE7578:
+	.size	_Z16transpose_scalarPA8_KfPA8_f, .-_Z16transpose_scalarPA8_KfPA8_f
+	.globl	_Z17transpose_avx_8x8PA8_KfPA8_f
+	.type	_Z17transpose_avx_8x8PA8_KfPA8_f, @function
+_Z17transpose_avx_8x8PA8_KfPA8_f:
+.LFB7579:
+	.cfi_startproc
+	endbr64
+	vmovups	(%rdi), %ymm6
+	vmovups	32(%rdi), %ymm4
+	vmovups	64(%rdi), %ymm0
+	vmovups	96(%rdi), %ymm2
+	vmovups	128(%rdi), %ymm1
+	vmovups	160(%rdi), %ymm5
+	vmovups	192(%rdi), %ymm3
+	vmovups	224(%rdi), %ymm8
+	vunpcklps	%ymm4, %ymm6, %ymm7
+	vunpckhps	%ymm4, %ymm6, %ymm6
+	vunpcklps	%ymm2, %ymm0, %ymm4
+	vunpckhps	%ymm2, %ymm0, %ymm0
+	vunpcklps	%ymm5, %ymm1, %ymm2
+	vunpckhps	%ymm5, %ymm1, %ymm1
+	vunpcklps	%ymm8, %ymm3, %ymm5
+	vunpckhps	%ymm8, %ymm3, %ymm3
+	vshufps	$68, %ymm4, %ymm7, %ymm8
+	vshufps	$238, %ymm4, %ymm7, %ymm4
+	vshufps	$68, %ymm0, %ymm6, %ymm7
+	vshufps	$238, %ymm0, %ymm6, %ymm0
+	vshufps	$68, %ymm5, %ymm2, %ymm6
+	vshufps	$238, %ymm5, %ymm2, %ymm2
+	vshufps	$68, %ymm3, %ymm1, %ymm5
+	vshufps	$238, %ymm3, %ymm1, %ymm1
+	vinsertf128	$1, %xmm6, %ymm8, %ymm12
+	vinsertf128	$1, %xmm2, %ymm4, %ymm11
+	vinsertf128	$1, %xmm5, %ymm7, %ymm10
+	vinsertf128	$1, %xmm1, %ymm0, %ymm9
+	vperm2f128	$49, %ymm6, %ymm8, %ymm3
+	vperm2f128	$49, %ymm2, %ymm4, %ymm4
+	vperm2f128	$49, %ymm5, %ymm7, %ymm2
+	vperm2f128	$49, %ymm1, %ymm0, %ymm0
+	vmovups	%ymm12, (%rsi)
+	vmovups	%ymm11, 32(%rsi)
+	vmovups	%ymm10, 64(%rsi)
+	vmovups	%ymm9, 96(%rsi)
+	vmovups	%ymm3, 128(%rsi)
+	vmovups	%ymm4, 160(%rsi)
+	vmovups	%ymm2, 192(%rsi)
+	vmovups	%ymm0, 224(%rsi)
+	ret
+	.cfi_endproc
+.LFE7579:
+	.size	_Z17transpose_avx_8x8PA8_KfPA8_f, .-_Z17transpose_avx_8x8PA8_KfPA8_f
+	.type	_GLOBAL__sub_I__Z16transpose_scalarPA8_KfPA8_f, @function
+_GLOBAL__sub_I__Z16transpose_scalarPA8_KfPA8_f:

--- a/Assembly_code-transpose/O2-assembly
+++ b/Assembly_code-transpose/O2-assembly
@@ -1,0 +1,89 @@
+	.file	"transpose.cpp"
+	.text
+	.p2align 4
+	.globl	_Z16transpose_scalarPA8_KfPA8_f
+	.type	_Z16transpose_scalarPA8_KfPA8_f, @function
+_Z16transpose_scalarPA8_KfPA8_f:
+.LFB7578:
+	.cfi_startproc
+	endbr64
+	leaq	32(%rdi), %rcx
+	leaq	32(%rsi), %rdi
+	.p2align 4,,10
+	.p2align 3
+.L2:
+	leaq	-32(%rcx), %rax
+	movq	%rsi, %rdx
+	.p2align 4,,10
+	.p2align 3
+.L3:
+	vmovss	(%rax), %xmm0
+	addq	$4, %rax
+	addq	$32, %rdx
+	vmovss	%xmm0, -32(%rdx)
+	cmpq	%rcx, %rax
+	jne	.L3
+	addq	$4, %rsi
+	leaq	32(%rax), %rcx
+	cmpq	%rdi, %rsi
+	jne	.L2
+	ret
+	.cfi_endproc
+.LFE7578:
+	.size	_Z16transpose_scalarPA8_KfPA8_f, .-_Z16transpose_scalarPA8_KfPA8_f
+	.p2align 4
+	.globl	_Z17transpose_avx_8x8PA8_KfPA8_f
+	.type	_Z17transpose_avx_8x8PA8_KfPA8_f, @function
+_Z17transpose_avx_8x8PA8_KfPA8_f:
+.LFB7579:
+	.cfi_startproc
+	endbr64
+	vmovups	32(%rdi), %ymm4
+	vmovups	96(%rdi), %ymm2
+	vmovups	160(%rdi), %ymm5
+	vmovups	224(%rdi), %ymm8
+	vmovups	(%rdi), %ymm6
+	vmovups	64(%rdi), %ymm0
+	vmovups	128(%rdi), %ymm1
+	vmovups	192(%rdi), %ymm3
+	vunpcklps	%ymm4, %ymm6, %ymm7
+	vunpckhps	%ymm4, %ymm6, %ymm6
+	vunpcklps	%ymm2, %ymm0, %ymm4
+	vunpckhps	%ymm2, %ymm0, %ymm0
+	vunpcklps	%ymm5, %ymm1, %ymm2
+	vunpckhps	%ymm5, %ymm1, %ymm1
+	vunpcklps	%ymm8, %ymm3, %ymm5
+	vunpckhps	%ymm8, %ymm3, %ymm3
+	vshufps	$68, %ymm4, %ymm7, %ymm8
+	vshufps	$238, %ymm4, %ymm7, %ymm4
+	vshufps	$68, %ymm0, %ymm6, %ymm7
+	vshufps	$238, %ymm0, %ymm6, %ymm0
+	vshufps	$68, %ymm5, %ymm2, %ymm6
+	vshufps	$238, %ymm5, %ymm2, %ymm2
+	vinsertf128	$1, %xmm6, %ymm8, %ymm12
+	vshufps	$68, %ymm3, %ymm1, %ymm5
+	vinsertf128	$1, %xmm2, %ymm4, %ymm11
+	vshufps	$238, %ymm3, %ymm1, %ymm1
+	vperm2f128	$49, %ymm2, %ymm4, %ymm4
+	vinsertf128	$1, %xmm1, %ymm0, %ymm9
+	vmovups	%ymm12, (%rsi)
+	vinsertf128	$1, %xmm5, %ymm7, %ymm10
+	vperm2f128	$49, %ymm6, %ymm8, %ymm3
+	vperm2f128	$49, %ymm5, %ymm7, %ymm2
+	vperm2f128	$49, %ymm1, %ymm0, %ymm0
+	vmovups	%ymm11, 32(%rsi)
+	vmovups	%ymm10, 64(%rsi)
+	vmovups	%ymm9, 96(%rsi)
+	vmovups	%ymm3, 128(%rsi)
+	vmovups	%ymm4, 160(%rsi)
+	vmovups	%ymm2, 192(%rsi)
+	vmovups	%ymm0, 224(%rsi)
+	vzeroupper
+	ret
+	.cfi_endproc
+.LFE7579:
+	.size	_Z17transpose_avx_8x8PA8_KfPA8_f, .-_Z17transpose_avx_8x8PA8_KfPA8_f
+	.section	.text.startup,"ax",@progbits
+	.p2align 4
+	.type	_GLOBAL__sub_I__Z16transpose_scalarPA8_KfPA8_f, @function
+_GLOBAL__sub_I__Z16transpose_scalarPA8_KfPA8_f:

--- a/Assembly_code-transpose/O3-assembly
+++ b/Assembly_code-transpose/O3-assembly
@@ -1,0 +1,334 @@
+	.file	"transpose.cpp"
+	.text
+	.p2align 4
+	.globl	_Z16transpose_scalarPA8_KfPA8_f
+	.type	_Z16transpose_scalarPA8_KfPA8_f, @function
+_Z16transpose_scalarPA8_KfPA8_f:
+.LFB7585:
+	.cfi_startproc
+	endbr64
+	leaq	255(%rdi), %rax
+	subq	%rsi, %rax
+	cmpq	$510, %rax
+	jbe	.L2
+	vmovups	32(%rdi), %ymm7
+	vmovups	(%rdi), %ymm4
+	vmovups	96(%rdi), %ymm8
+	vmovups	64(%rdi), %ymm0
+	vshufps	$136, %ymm7, %ymm4, %ymm6
+	vperm2f128	$3, %ymm6, %ymm6, %ymm5
+	vshufps	$221, %ymm7, %ymm4, %ymm4
+	vmovups	160(%rdi), %ymm10
+	vshufps	$68, %ymm5, %ymm6, %ymm2
+	vshufps	$238, %ymm5, %ymm6, %ymm5
+	vperm2f128	$3, %ymm4, %ymm4, %ymm6
+	vmovups	128(%rdi), %ymm3
+	vinsertf128	$1, %xmm5, %ymm2, %ymm2
+	vshufps	$68, %ymm6, %ymm4, %ymm5
+	vshufps	$238, %ymm6, %ymm4, %ymm6
+	vinsertf128	$1, %xmm6, %ymm5, %ymm5
+	vshufps	$136, %ymm8, %ymm0, %ymm6
+	vperm2f128	$3, %ymm6, %ymm6, %ymm4
+	vshufps	$221, %ymm8, %ymm0, %ymm0
+	vmovups	224(%rdi), %ymm9
+	vshufps	$68, %ymm4, %ymm6, %ymm7
+	vshufps	$238, %ymm4, %ymm6, %ymm4
+	vinsertf128	$1, %xmm4, %ymm7, %ymm7
+	vperm2f128	$3, %ymm0, %ymm0, %ymm4
+	vmovups	192(%rdi), %ymm1
+	vshufps	$136, %ymm10, %ymm3, %ymm6
+	vshufps	$68, %ymm4, %ymm0, %ymm8
+	vshufps	$238, %ymm4, %ymm0, %ymm4
+	vinsertf128	$1, %xmm4, %ymm8, %ymm8
+	vperm2f128	$3, %ymm6, %ymm6, %ymm4
+	vshufps	$221, %ymm10, %ymm3, %ymm3
+	vshufps	$68, %ymm4, %ymm6, %ymm0
+	vshufps	$238, %ymm4, %ymm6, %ymm4
+	vperm2f128	$3, %ymm3, %ymm3, %ymm6
+	vshufps	$136, %ymm9, %ymm1, %ymm10
+	vinsertf128	$1, %xmm4, %ymm0, %ymm0
+	vshufps	$68, %ymm6, %ymm3, %ymm4
+	vshufps	$238, %ymm6, %ymm3, %ymm6
+	vperm2f128	$3, %ymm10, %ymm10, %ymm3
+	vshufps	$221, %ymm9, %ymm1, %ymm1
+	vinsertf128	$1, %xmm6, %ymm4, %ymm4
+	vshufps	$68, %ymm3, %ymm10, %ymm6
+	vshufps	$238, %ymm3, %ymm10, %ymm3
+	vinsertf128	$1, %xmm3, %ymm6, %ymm6
+	vperm2f128	$3, %ymm1, %ymm1, %ymm3
+	vshufps	$136, %ymm7, %ymm2, %ymm10
+	vshufps	$221, %ymm7, %ymm2, %ymm2
+	vshufps	$68, %ymm3, %ymm1, %ymm9
+	vperm2f128	$3, %ymm2, %ymm2, %ymm7
+	vshufps	$238, %ymm3, %ymm1, %ymm3
+	vperm2f128	$3, %ymm10, %ymm10, %ymm1
+	vinsertf128	$1, %xmm3, %ymm9, %ymm9
+	vshufps	$68, %ymm1, %ymm10, %ymm3
+	vshufps	$238, %ymm1, %ymm10, %ymm1
+	vshufps	$136, %ymm6, %ymm0, %ymm10
+	vinsertf128	$1, %xmm1, %ymm3, %ymm3
+	vshufps	$68, %ymm7, %ymm2, %ymm1
+	vshufps	$238, %ymm7, %ymm2, %ymm7
+	vperm2f128	$3, %ymm10, %ymm10, %ymm2
+	vshufps	$221, %ymm6, %ymm0, %ymm0
+	vinsertf128	$1, %xmm7, %ymm1, %ymm1
+	vshufps	$68, %ymm2, %ymm10, %ymm7
+	vshufps	$238, %ymm2, %ymm10, %ymm2
+	vinsertf128	$1, %xmm2, %ymm7, %ymm7
+	vperm2f128	$3, %ymm0, %ymm0, %ymm2
+	vshufps	$136, %ymm8, %ymm5, %ymm10
+	vshufps	$221, %ymm8, %ymm5, %ymm5
+	vshufps	$68, %ymm2, %ymm0, %ymm6
+	vperm2f128	$3, %ymm5, %ymm5, %ymm8
+	vshufps	$238, %ymm2, %ymm0, %ymm2
+	vperm2f128	$3, %ymm10, %ymm10, %ymm0
+	vinsertf128	$1, %xmm2, %ymm6, %ymm6
+	vshufps	$68, %ymm0, %ymm10, %ymm2
+	vshufps	$238, %ymm0, %ymm10, %ymm0
+	vshufps	$136, %ymm9, %ymm4, %ymm10
+	vinsertf128	$1, %xmm0, %ymm2, %ymm2
+	vshufps	$68, %ymm8, %ymm5, %ymm0
+	vshufps	$238, %ymm8, %ymm5, %ymm8
+	vinsertf128	$1, %xmm8, %ymm0, %ymm0
+	vperm2f128	$3, %ymm10, %ymm10, %ymm8
+	vshufps	$221, %ymm9, %ymm4, %ymm4
+	vshufps	$68, %ymm8, %ymm10, %ymm5
+	vshufps	$238, %ymm8, %ymm10, %ymm8
+	vinsertf128	$1, %xmm8, %ymm5, %ymm5
+	vperm2f128	$3, %ymm4, %ymm4, %ymm8
+	vshufps	$68, %ymm8, %ymm4, %ymm9
+	vshufps	$238, %ymm8, %ymm4, %ymm8
+	vinsertf128	$1, %xmm8, %ymm9, %ymm4
+	vshufps	$136, %ymm7, %ymm3, %ymm9
+	vperm2f128	$3, %ymm9, %ymm9, %ymm8
+	vshufps	$221, %ymm7, %ymm3, %ymm3
+	vperm2f128	$3, %ymm3, %ymm3, %ymm7
+	vshufps	$68, %ymm8, %ymm9, %ymm10
+	vshufps	$238, %ymm8, %ymm9, %ymm8
+	vinsertf128	$1, %xmm8, %ymm10, %ymm8
+	vshufps	$136, %ymm5, %ymm2, %ymm9
+	vmovups	%ymm8, (%rsi)
+	vperm2f128	$3, %ymm9, %ymm9, %ymm8
+	vshufps	$221, %ymm5, %ymm2, %ymm2
+	vshufps	$68, %ymm8, %ymm9, %ymm10
+	vshufps	$238, %ymm8, %ymm9, %ymm8
+	vinsertf128	$1, %xmm8, %ymm10, %ymm8
+	vshufps	$136, %ymm6, %ymm1, %ymm9
+	vmovups	%ymm8, 32(%rsi)
+	vperm2f128	$3, %ymm9, %ymm9, %ymm8
+	vshufps	$221, %ymm6, %ymm1, %ymm1
+	vshufps	$68, %ymm8, %ymm9, %ymm10
+	vshufps	$238, %ymm8, %ymm9, %ymm8
+	vinsertf128	$1, %xmm8, %ymm10, %ymm8
+	vshufps	$136, %ymm4, %ymm0, %ymm9
+	vmovups	%ymm8, 64(%rsi)
+	vperm2f128	$3, %ymm9, %ymm9, %ymm8
+	vshufps	$221, %ymm4, %ymm0, %ymm0
+	vshufps	$68, %ymm8, %ymm9, %ymm10
+	vshufps	$238, %ymm8, %ymm9, %ymm8
+	vinsertf128	$1, %xmm8, %ymm10, %ymm8
+	vmovups	%ymm8, 96(%rsi)
+	vshufps	$68, %ymm7, %ymm3, %ymm8
+	vshufps	$238, %ymm7, %ymm3, %ymm7
+	vinsertf128	$1, %xmm7, %ymm8, %ymm3
+	vmovups	%ymm3, 128(%rsi)
+	vperm2f128	$3, %ymm2, %ymm2, %ymm3
+	vshufps	$68, %ymm3, %ymm2, %ymm5
+	vshufps	$238, %ymm3, %ymm2, %ymm3
+	vinsertf128	$1, %xmm3, %ymm5, %ymm2
+	vmovups	%ymm2, 160(%rsi)
+	vperm2f128	$3, %ymm1, %ymm1, %ymm2
+	vshufps	$68, %ymm2, %ymm1, %ymm3
+	vshufps	$238, %ymm2, %ymm1, %ymm2
+	vinsertf128	$1, %xmm2, %ymm3, %ymm1
+	vmovups	%ymm1, 192(%rsi)
+	vperm2f128	$3, %ymm0, %ymm0, %ymm1
+	vshufps	$68, %ymm1, %ymm0, %ymm2
+	vshufps	$238, %ymm1, %ymm0, %ymm1
+	vinsertf128	$1, %xmm1, %ymm2, %ymm0
+	vmovups	%ymm0, 224(%rsi)
+	vzeroupper
+	ret
+.L2:
+	vmovss	(%rdi), %xmm0
+	vmovss	%xmm0, (%rsi)
+	vmovss	4(%rdi), %xmm0
+	vmovss	%xmm0, 32(%rsi)
+	vmovss	8(%rdi), %xmm0
+	vmovss	%xmm0, 64(%rsi)
+	vmovss	12(%rdi), %xmm0
+	vmovss	%xmm0, 96(%rsi)
+	vmovss	16(%rdi), %xmm0
+	vmovss	%xmm0, 128(%rsi)
+	vmovss	20(%rdi), %xmm0
+	vmovss	%xmm0, 160(%rsi)
+	vmovss	24(%rdi), %xmm0
+	vmovss	%xmm0, 192(%rsi)
+	vmovss	28(%rdi), %xmm0
+	vmovss	%xmm0, 224(%rsi)
+	vmovss	32(%rdi), %xmm0
+	vmovss	%xmm0, 4(%rsi)
+	vmovss	36(%rdi), %xmm0
+	vmovss	%xmm0, 36(%rsi)
+	vmovss	40(%rdi), %xmm0
+	vmovss	%xmm0, 68(%rsi)
+	vmovss	44(%rdi), %xmm0
+	vmovss	%xmm0, 100(%rsi)
+	vmovss	48(%rdi), %xmm0
+	vmovss	%xmm0, 132(%rsi)
+	vmovss	52(%rdi), %xmm0
+	vmovss	%xmm0, 164(%rsi)
+	vmovss	56(%rdi), %xmm0
+	vmovss	%xmm0, 196(%rsi)
+	vmovss	60(%rdi), %xmm0
+	vmovss	%xmm0, 228(%rsi)
+	vmovss	64(%rdi), %xmm0
+	vmovss	%xmm0, 8(%rsi)
+	vmovss	68(%rdi), %xmm0
+	vmovss	%xmm0, 40(%rsi)
+	vmovss	72(%rdi), %xmm0
+	vmovss	%xmm0, 72(%rsi)
+	vmovss	76(%rdi), %xmm0
+	vmovss	%xmm0, 104(%rsi)
+	vmovss	80(%rdi), %xmm0
+	vmovss	%xmm0, 136(%rsi)
+	vmovss	84(%rdi), %xmm0
+	vmovss	%xmm0, 168(%rsi)
+	vmovss	88(%rdi), %xmm0
+	vmovss	%xmm0, 200(%rsi)
+	vmovss	92(%rdi), %xmm0
+	vmovss	%xmm0, 232(%rsi)
+	vmovss	96(%rdi), %xmm0
+	vmovss	%xmm0, 12(%rsi)
+	vmovss	100(%rdi), %xmm0
+	vmovss	%xmm0, 44(%rsi)
+	vmovss	104(%rdi), %xmm0
+	vmovss	%xmm0, 76(%rsi)
+	vmovss	108(%rdi), %xmm0
+	vmovss	%xmm0, 108(%rsi)
+	vmovss	112(%rdi), %xmm0
+	vmovss	%xmm0, 140(%rsi)
+	vmovss	116(%rdi), %xmm0
+	vmovss	%xmm0, 172(%rsi)
+	vmovss	120(%rdi), %xmm0
+	vmovss	%xmm0, 204(%rsi)
+	vmovss	124(%rdi), %xmm0
+	vmovss	%xmm0, 236(%rsi)
+	vmovss	128(%rdi), %xmm0
+	vmovss	%xmm0, 16(%rsi)
+	vmovss	132(%rdi), %xmm0
+	vmovss	%xmm0, 48(%rsi)
+	vmovss	136(%rdi), %xmm0
+	vmovss	%xmm0, 80(%rsi)
+	vmovss	140(%rdi), %xmm0
+	vmovss	%xmm0, 112(%rsi)
+	vmovss	144(%rdi), %xmm0
+	vmovss	%xmm0, 144(%rsi)
+	vmovss	148(%rdi), %xmm0
+	vmovss	%xmm0, 176(%rsi)
+	vmovss	152(%rdi), %xmm0
+	vmovss	%xmm0, 208(%rsi)
+	vmovss	156(%rdi), %xmm0
+	vmovss	%xmm0, 240(%rsi)
+	vmovss	160(%rdi), %xmm0
+	vmovss	%xmm0, 20(%rsi)
+	vmovss	164(%rdi), %xmm0
+	vmovss	%xmm0, 52(%rsi)
+	vmovss	168(%rdi), %xmm0
+	vmovss	%xmm0, 84(%rsi)
+	vmovss	172(%rdi), %xmm0
+	vmovss	%xmm0, 116(%rsi)
+	vmovss	176(%rdi), %xmm0
+	vmovss	%xmm0, 148(%rsi)
+	vmovss	180(%rdi), %xmm0
+	vmovss	%xmm0, 180(%rsi)
+	vmovss	184(%rdi), %xmm0
+	vmovss	%xmm0, 212(%rsi)
+	vmovss	188(%rdi), %xmm0
+	vmovss	%xmm0, 244(%rsi)
+	vmovss	192(%rdi), %xmm0
+	vmovss	%xmm0, 24(%rsi)
+	vmovss	196(%rdi), %xmm0
+	vmovss	%xmm0, 56(%rsi)
+	vmovss	200(%rdi), %xmm0
+	vmovss	%xmm0, 88(%rsi)
+	vmovss	204(%rdi), %xmm0
+	vmovss	%xmm0, 120(%rsi)
+	vmovss	208(%rdi), %xmm0
+	vmovss	%xmm0, 152(%rsi)
+	vmovss	212(%rdi), %xmm0
+	vmovss	%xmm0, 184(%rsi)
+	vmovss	216(%rdi), %xmm0
+	vmovss	%xmm0, 216(%rsi)
+	vmovss	220(%rdi), %xmm0
+	vmovss	%xmm0, 248(%rsi)
+	vmovss	224(%rdi), %xmm0
+	vmovss	%xmm0, 28(%rsi)
+	vmovss	228(%rdi), %xmm0
+	vmovss	%xmm0, 60(%rsi)
+	vmovss	232(%rdi), %xmm0
+	vmovss	%xmm0, 92(%rsi)
+	vmovss	236(%rdi), %xmm0
+	vmovss	%xmm0, 124(%rsi)
+	vmovss	240(%rdi), %xmm0
+	vmovss	%xmm0, 156(%rsi)
+	vmovss	244(%rdi), %xmm0
+	vmovss	%xmm0, 188(%rsi)
+	vmovss	248(%rdi), %xmm0
+	vmovss	%xmm0, 220(%rsi)
+	vmovss	252(%rdi), %xmm0
+	vmovss	%xmm0, 252(%rsi)
+	ret
+	.cfi_endproc
+.LFE7585:
+	.size	_Z16transpose_scalarPA8_KfPA8_f, .-_Z16transpose_scalarPA8_KfPA8_f
+	.p2align 4
+	.globl	_Z17transpose_avx_8x8PA8_KfPA8_f
+	.type	_Z17transpose_avx_8x8PA8_KfPA8_f, @function
+_Z17transpose_avx_8x8PA8_KfPA8_f:
+.LFB7586:
+	.cfi_startproc
+	endbr64
+	vmovups	32(%rdi), %ymm4
+	vmovups	96(%rdi), %ymm2
+	vmovups	160(%rdi), %ymm5
+	vmovups	224(%rdi), %ymm8
+	vmovups	(%rdi), %ymm6
+	vmovups	64(%rdi), %ymm0
+	vmovups	128(%rdi), %ymm1
+	vmovups	192(%rdi), %ymm3
+	vunpcklps	%ymm4, %ymm6, %ymm7
+	vunpckhps	%ymm4, %ymm6, %ymm6
+	vunpcklps	%ymm2, %ymm0, %ymm4
+	vunpckhps	%ymm2, %ymm0, %ymm0
+	vunpcklps	%ymm5, %ymm1, %ymm2
+	vunpckhps	%ymm5, %ymm1, %ymm1
+	vunpcklps	%ymm8, %ymm3, %ymm5
+	vunpckhps	%ymm8, %ymm3, %ymm3
+	vshufps	$68, %ymm4, %ymm7, %ymm8
+	vshufps	$238, %ymm4, %ymm7, %ymm4
+	vshufps	$68, %ymm0, %ymm6, %ymm7
+	vshufps	$238, %ymm0, %ymm6, %ymm0
+	vshufps	$68, %ymm5, %ymm2, %ymm6
+	vshufps	$238, %ymm5, %ymm2, %ymm2
+	vinsertf128	$1, %xmm6, %ymm8, %ymm12
+	vshufps	$68, %ymm3, %ymm1, %ymm5
+	vinsertf128	$1, %xmm2, %ymm4, %ymm11
+	vshufps	$238, %ymm3, %ymm1, %ymm1
+	vperm2f128	$49, %ymm2, %ymm4, %ymm4
+	vinsertf128	$1, %xmm1, %ymm0, %ymm9
+	vmovups	%ymm12, (%rsi)
+	vinsertf128	$1, %xmm5, %ymm7, %ymm10
+	vperm2f128	$49, %ymm6, %ymm8, %ymm3
+	vperm2f128	$49, %ymm5, %ymm7, %ymm2
+	vperm2f128	$49, %ymm1, %ymm0, %ymm0
+	vmovups	%ymm11, 32(%rsi)
+	vmovups	%ymm10, 64(%rsi)
+	vmovups	%ymm9, 96(%rsi)
+	vmovups	%ymm3, 128(%rsi)
+	vmovups	%ymm4, 160(%rsi)
+	vmovups	%ymm2, 192(%rsi)
+	vmovups	%ymm0, 224(%rsi)
+	vzeroupper
+	ret
+	.cfi_endproc

--- a/transpose.cpp
+++ b/transpose.cpp
@@ -1,83 +1,129 @@
-#include </home/mlir/MLIR/mlir-emitc/third_party/googletest/googletest/include/gtest/gtest.h>
 #include <immintrin.h>
 #include <iostream>
-#include <vector>
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
 
-// Scalar 4x4 transpose
-void transpose4x4_scalar(const std::vector<float>& src, std::vector<float>& dst, int rows, int cols) {
-    for(int i = 0; i < rows; ++i)
-        for(int j = 0; j < cols; ++j)
-            dst[j*cols + i] = src[i*cols + j];
+inline void transpose8_ps(__m256 &row0, __m256 &row1, __m256 &row2, __m256 &row3,
+                          __m256 &row4, __m256 &row5, __m256 &row6, __m256 &row7) {
+
+//  _mm256_unpacklo_ps(a, b) → interleaves lower 4 elements (lane-wise) of a and b.
+// → Result: [a0, b0, a1, b1, a2, b2, a3, b3]
+
+// _mm256_unpackhi_ps(a, b) → interleaves higher 4 elements of a and b.
+// → Result: [a4, b4, a5, b5, a6, b6, a7, b7]
+
+// These help pair up rows (row0 with row1, row2 with row3, etc.) — essentially forming 2×2 sub-blocks of the transpose.
+    __m256 t0 = _mm256_unpacklo_ps(row0, row1);
+    __m256 t1 = _mm256_unpackhi_ps(row0, row1);
+    __m256 t2 = _mm256_unpacklo_ps(row2, row3);
+    __m256 t3 = _mm256_unpackhi_ps(row2, row3);
+    __m256 t4 = _mm256_unpacklo_ps(row4, row5);
+    __m256 t5 = _mm256_unpackhi_ps(row4, row5);
+    __m256 t6 = _mm256_unpacklo_ps(row6, row7);
+    __m256 t7 = _mm256_unpackhi_ps(row6, row7);
+
+    // _mm256_shuffle_ps(a, b, imm) → shuffles elements from a and b based on the immediate control value imm.
+    // _MM_SHUFFLE(z, y, x, w) → creates an immediate value for shuffling.
+    // This step rearranges the data to prepare for the final permutation.
+
+    __m256 tt0 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(1,0,1,0));
+    __m256 tt1 = _mm256_shuffle_ps(t0, t2, _MM_SHUFFLE(3,2,3,2));
+    __m256 tt2 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(1,0,1,0));
+    __m256 tt3 = _mm256_shuffle_ps(t1, t3, _MM_SHUFFLE(3,2,3,2));
+    __m256 tt4 = _mm256_shuffle_ps(t4, t6, _MM_SHUFFLE(1,0,1,0));
+    __m256 tt5 = _mm256_shuffle_ps(t4, t6, _MM_SHUFFLE(3,2,3,2));
+    __m256 tt6 = _mm256_shuffle_ps(t5, t7, _MM_SHUFFLE(1,0,1,0));
+    __m256 tt7 = _mm256_shuffle_ps(t5, t7, _MM_SHUFFLE(3,2,3,2));
+
+    // _mm256_permute2f128_ps(a, b, imm) → rearranges 128-bit halves (lanes) between two 256-bit registers.
+    // 0x20 → [b.low | a.low]
+    // 0x31 → [b.high | a.high]
+    // These combine data from the lower and upper 128-bit lanes of the shuffled results to form the final 8×8 transposed output.
+
+    row0 = _mm256_permute2f128_ps(tt0, tt4, 0x20);
+    row1 = _mm256_permute2f128_ps(tt1, tt5, 0x20);
+    row2 = _mm256_permute2f128_ps(tt2, tt6, 0x20);
+    row3 = _mm256_permute2f128_ps(tt3, tt7, 0x20);
+    row4 = _mm256_permute2f128_ps(tt0, tt4, 0x31);
+    row5 = _mm256_permute2f128_ps(tt1, tt5, 0x31);
+    row6 = _mm256_permute2f128_ps(tt2, tt6, 0x31);
+    row7 = _mm256_permute2f128_ps(tt3, tt7, 0x31);
 }
 
-// AVX 4x4 transpose
-void transpose4x4_avx(const std::vector<float>& src, std::vector<float>& dst, int rows, int cols) {
-    __m128 row0 = _mm_loadu_ps(&src[0]);
-    __m128 row1 = _mm_loadu_ps(&src[4]);
-    __m128 row2 = _mm_loadu_ps(&src[8]);
-    __m128 row3 = _mm_loadu_ps(&src[12]);
-
-    __m128 tmp0 = _mm_unpacklo_ps(row0, row1);
-    __m128 tmp1 = _mm_unpackhi_ps(row0, row1);
-    __m128 tmp2 = _mm_unpacklo_ps(row2, row3);
-    __m128 tmp3 = _mm_unpackhi_ps(row2, row3);
-
-    row0 = _mm_movelh_ps(tmp0, tmp2);
-    row1 = _mm_movehl_ps(tmp2, tmp0);
-    row2 = _mm_movelh_ps(tmp1, tmp3);
-    row3 = _mm_movehl_ps(tmp3, tmp1);
-
-    _mm_storeu_ps(&dst[0], row0);
-    _mm_storeu_ps(&dst[4], row1);
-    _mm_storeu_ps(&dst[8], row2);
-    _mm_storeu_ps(&dst[12], row3);
+void transpose_scalar(const float in[8][8], float out[8][8]) {
+    for (int r = 0; r < 8; ++r)
+        for (int c = 0; c < 8; ++c)
+            out[c][r] = in[r][c];
 }
 
-int main() {
-    const int rows = 4, cols = 4;
-    const int elements = rows * cols;
-    const int iterations = 1000;
+// Each row of 8 floats is loaded into a 256-bit AVX register (__m256), which holds 8 floats (8 × 32 bits = 256 bits).
+// So, the entire 8×8 matrix fits into 8 AVX registers:
+void transpose_avx_8x8(const float in[8][8], float out[8][8]) {
+    // loads 8 floats (256 bits) from memory into an AVX register.
+    __m256 r0 = _mm256_loadu_ps(in[0]);
+    __m256 r1 = _mm256_loadu_ps(in[1]);
+    __m256 r2 = _mm256_loadu_ps(in[2]);
+    __m256 r3 = _mm256_loadu_ps(in[3]);
+    __m256 r4 = _mm256_loadu_ps(in[4]);
+    __m256 r5 = _mm256_loadu_ps(in[5]);
+    __m256 r6 = _mm256_loadu_ps(in[6]);
+    __m256 r7 = _mm256_loadu_ps(in[7]);
 
-    std::vector<float> mat(elements), trans_scalar(elements), trans_avx(elements);
+    transpose8_ps(r0, r1, r2, r3, r4, r5, r6, r7);
 
-    std::cout << "Enter 4x4 matrix elements row-wise:\n";
-    for(int i = 0; i < elements; ++i)
-        std::cin >> mat[i];
+    // stores 8 floats (256 bits) from an AVX register to memory.
+    _mm256_storeu_ps(out[0], r0);
+    _mm256_storeu_ps(out[1], r1);
+    _mm256_storeu_ps(out[2], r2);
+    _mm256_storeu_ps(out[3], r3);
+    _mm256_storeu_ps(out[4], r4);
+    _mm256_storeu_ps(out[5], r5);
+    _mm256_storeu_ps(out[6], r6);
+    _mm256_storeu_ps(out[7], r7);
+}
 
-    // Measure scalar transpose
-    long long total_scalar_time = 0;
-    for(int it = 0; it < iterations; ++it) {
-        auto start = std::chrono::high_resolution_clock::now();
-        transpose4x4_scalar(mat, trans_scalar, rows, cols);
-        auto end = std::chrono::high_resolution_clock::now();
-        total_scalar_time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+TEST(MatrixTransposeTest, AVX8x8_vs_Scalar) {
+    float A[8][8];
+    float B_scalar[8][8];
+    float B_avx[8][8];
+
+    std::srand(static_cast<unsigned>(std::time(nullptr)));
+
+    for (int i = 0; i < 8; ++i)
+        for (int j = 0; j < 8; ++j)
+            A[i][j] = static_cast<float>(std::rand()) / RAND_MAX;
+
+    const int iterations = 100;
+    long long scalar_time = 0;
+    long long avx_time = 0;
+
+    for (int i = 0; i < iterations; ++i) {
+        auto t0 = std::chrono::high_resolution_clock::now();
+        transpose_scalar(A, B_scalar);
+        auto t1 = std::chrono::high_resolution_clock::now();
+        scalar_time += std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count();
+
+        auto t0_avx = std::chrono::high_resolution_clock::now();
+        transpose_avx_8x8(A, B_avx);
+        auto t1_avx = std::chrono::high_resolution_clock::now();
+        avx_time += std::chrono::duration_cast<std::chrono::nanoseconds>(t1_avx - t0_avx).count();
     }
-    double avg_scalar_time_ns = total_scalar_time / static_cast<double>(iterations);
 
-    // Measure AVX transpose
-    long long total_avx_time = 0;
-    for(int it = 0; it < iterations; ++it) {
-        auto start = std::chrono::high_resolution_clock::now();
-        transpose4x4_avx(mat, trans_avx, rows, cols);
-        auto end = std::chrono::high_resolution_clock::now();
-        total_avx_time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
-    }
-    double avg_avx_time_ns = total_avx_time / static_cast<double>(iterations);
+    double avg_scalar = scalar_time / static_cast<double>(iterations);
+    double avg_avx = avx_time / static_cast<double>(iterations);
+    double speedup = avg_scalar / avg_avx;
 
-    // Print AVX transposed matrix
-    std::cout << "\nTransposed 4x4 matrix (AVX last iteration):\n";
-    for(int i = 0; i < rows; ++i) {
-        for(int j = 0; j < cols; ++j)
-            std::cout << trans_avx[i*cols + j] << " ";
-        std::cout << "\n";
-    }
+    std::cout << "\nAverage Scalar Transpose Time: " << avg_scalar << " ns\n";
+    std::cout << "Average AVX Transpose Time:    " << avg_avx << " ns\n";
+    std::cout << "Speedup: " << speedup << "x\n";
+// This Approach is 6-7x faster than the scalar version.
+    for (int i = 0; i < 8; ++i)
+        for (int j = 0; j < 8; ++j)
+            EXPECT_NEAR(B_scalar[i][j], B_avx[i][j], 1e-5);
+}
 
-    std::cout << "Average scalar transpose: " << avg_scalar_time_ns << " ns\n";
-    std::cout << "Average AVX transpose:    " << avg_avx_time_ns << " ns\n";
-    std::cout << "Speedup: " << avg_scalar_time_ns / avg_avx_time_ns << "x\n";
-
-    return 0;
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/transpose.cpp
+++ b/transpose.cpp
@@ -1,0 +1,83 @@
+#include </home/mlir/MLIR/mlir-emitc/third_party/googletest/googletest/include/gtest/gtest.h>
+#include <immintrin.h>
+#include <iostream>
+#include <vector>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+
+// Scalar 4x4 transpose
+void transpose4x4_scalar(const std::vector<float>& src, std::vector<float>& dst, int rows, int cols) {
+    for(int i = 0; i < rows; ++i)
+        for(int j = 0; j < cols; ++j)
+            dst[j*cols + i] = src[i*cols + j];
+}
+
+// AVX 4x4 transpose
+void transpose4x4_avx(const std::vector<float>& src, std::vector<float>& dst, int rows, int cols) {
+    __m128 row0 = _mm_loadu_ps(&src[0]);
+    __m128 row1 = _mm_loadu_ps(&src[4]);
+    __m128 row2 = _mm_loadu_ps(&src[8]);
+    __m128 row3 = _mm_loadu_ps(&src[12]);
+
+    __m128 tmp0 = _mm_unpacklo_ps(row0, row1);
+    __m128 tmp1 = _mm_unpackhi_ps(row0, row1);
+    __m128 tmp2 = _mm_unpacklo_ps(row2, row3);
+    __m128 tmp3 = _mm_unpackhi_ps(row2, row3);
+
+    row0 = _mm_movelh_ps(tmp0, tmp2);
+    row1 = _mm_movehl_ps(tmp2, tmp0);
+    row2 = _mm_movelh_ps(tmp1, tmp3);
+    row3 = _mm_movehl_ps(tmp3, tmp1);
+
+    _mm_storeu_ps(&dst[0], row0);
+    _mm_storeu_ps(&dst[4], row1);
+    _mm_storeu_ps(&dst[8], row2);
+    _mm_storeu_ps(&dst[12], row3);
+}
+
+int main() {
+    const int rows = 4, cols = 4;
+    const int elements = rows * cols;
+    const int iterations = 1000;
+
+    std::vector<float> mat(elements), trans_scalar(elements), trans_avx(elements);
+
+    std::cout << "Enter 4x4 matrix elements row-wise:\n";
+    for(int i = 0; i < elements; ++i)
+        std::cin >> mat[i];
+
+    // Measure scalar transpose
+    long long total_scalar_time = 0;
+    for(int it = 0; it < iterations; ++it) {
+        auto start = std::chrono::high_resolution_clock::now();
+        transpose4x4_scalar(mat, trans_scalar, rows, cols);
+        auto end = std::chrono::high_resolution_clock::now();
+        total_scalar_time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    }
+    double avg_scalar_time_ns = total_scalar_time / static_cast<double>(iterations);
+
+    // Measure AVX transpose
+    long long total_avx_time = 0;
+    for(int it = 0; it < iterations; ++it) {
+        auto start = std::chrono::high_resolution_clock::now();
+        transpose4x4_avx(mat, trans_avx, rows, cols);
+        auto end = std::chrono::high_resolution_clock::now();
+        total_avx_time += std::chrono::duration_cast<std::chrono::nanoseconds>(end - start).count();
+    }
+    double avg_avx_time_ns = total_avx_time / static_cast<double>(iterations);
+
+    // Print AVX transposed matrix
+    std::cout << "\nTransposed 4x4 matrix (AVX last iteration):\n";
+    for(int i = 0; i < rows; ++i) {
+        for(int j = 0; j < cols; ++j)
+            std::cout << trans_avx[i*cols + j] << " ";
+        std::cout << "\n";
+    }
+
+    std::cout << "Average scalar transpose: " << avg_scalar_time_ns << " ns\n";
+    std::cout << "Average AVX transpose:    " << avg_avx_time_ns << " ns\n";
+    std::cout << "Speedup: " << avg_scalar_time_ns / avg_avx_time_ns << "x\n";
+
+    return 0;
+}


### PR DESCRIPTION
This PR includes:
- Implemented 8x8 matrix transpose using both scalar and avx intrinsics using permute and shuffle . 
- Measured performance over multiple iterations by calculating the average execution time for scalar and intrinsic implementations.
 Which is 6-7x times faster than the scalar transpose.
- Added Google Test (GTest) to verify correctness of the intrinsic implementation against the scalar version.
